### PR TITLE
Feature/passport local

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+    "extends": "airbnb",
+    "plugins": [
+        "react",
+        "jsx-a11y",
+        "import"
+    ]
+};

--- a/app.js
+++ b/app.js
@@ -38,13 +38,19 @@ app.use(require('express-session')({
   saveUninitialized: false,
 }));
 
+// // TEMPORARILY LOGGER
+// app.use('*', (req, res, next) => {
+//   console.log(req.session);
+//   next();
+// });
+
 app.use(
   '/graph',
   graphQLExpress(request => ({
     graphiql: true,
     schema: Schema,
     mutation,
-    rootValue: { session: request.session },
+    rootValue: request.session,
   })),
 );
 

--- a/app.js
+++ b/app.js
@@ -1,23 +1,55 @@
-const express = require("express");
+/* eslint-disable no-console */
+const express = require('express');
+const passport = require('passport');
+
+const LocalStrategy = require('passport-local').Strategy;
+
+const app = express();
 const port = 3000;
-const keys = require("./config/keys");
-const mongoose = require("mongoose");
-const graphQLExpress = require("express-graphql");
-const Schema = require("./graphql/query/schema");
-const mutation = require("./graphql/mutation");
+const keys = require('./config/keys');
+const mongoose = require('mongoose');
+const graphQLExpress = require('express-graphql');
+const Schema = require('./graphql/query/schema');
+const mutation = require('./graphql/mutation');
+const User = require('./mongoose/models/user');
+const routes = require('./routes');
 
-mongoose.connect(keys.database.URI).then(()=>{
-    console.log("Database Connected");
-},
-err =>{console.log("Datbase connection error: " + err)});
-var app = express();
+mongoose.connect(keys.database.URI).then(
+  () => {
+    console.log('Database Connected');
+  },
+  (err) => {
+    console.log(`Database connection error: ${err}`);
+  },
+);
 
-app.use("/graph",graphQLExpress({
-    graphiql: true,
-    schema:Schema,
-    mutation:mutation
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(passport.initialize());
+app.use(passport.session());
+
+passport.use(new LocalStrategy(User.authenticate()));
+passport.serializeUser(User.serializeUser());
+passport.deserializeUser(User.deserializeUser());
+
+app.use(require('express-session')({
+  secret: 'the dog ate my homework',
+  resave: false,
+  saveUninitialized: false,
 }));
 
-app.listen(port,()=>{
-    console.log("App runing on port " + port);
-})
+app.use(
+  '/graph',
+  graphQLExpress(request => ({
+    graphiql: true,
+    schema: Schema,
+    mutation,
+    rootValue: { session: request.session },
+  })),
+);
+
+app.use(routes);
+
+app.listen(port, () => {
+  console.log(`App running on port ${port}`);
+});

--- a/app.js
+++ b/app.js
@@ -38,12 +38,6 @@ app.use(require('express-session')({
   saveUninitialized: false,
 }));
 
-// // TEMPORARILY LOGGER
-// app.use('*', (req, res, next) => {
-//   console.log(req.session);
-//   next();
-// });
-
 app.use(
   '/graph',
   graphQLExpress(request => ({

--- a/controllers/AuthController.js
+++ b/controllers/AuthController.js
@@ -1,0 +1,47 @@
+/* eslint-disable func-names */
+
+const mongoose = require('mongoose');
+const passport = require('passport');
+const User = require('../mongoose/models/user');
+
+const userController = {};
+
+userController.doRegister = function (req, res) {
+  const {
+    username, password, firstName, lastName, organization,
+  } = req.body;
+  const role = 'Admin';
+  User.register(
+    new User({
+      username,
+      firstName,
+      lastName,
+      organization,
+      role,
+    }),
+    password,
+    (err, user) => {
+      if (err) {
+        return res.send({ message: `AuthController Error: ${err}` });
+      }
+      return passport.authenticate('local')(req, res, () => {
+        console.log(user);
+        res.send({ message: `Welcome. You are ${user.username}.` });
+      });
+    },
+  );
+};
+
+userController.doLogin = function (req, res) {
+  passport.authenticate('local')(req, res, () => {
+    res.send({ message: `Logged in as ${req.user.username}!` });
+  });
+};
+
+userController.logout = function (req, res) {
+  req.logout();
+  console.log(req.user);
+  return res.send({ message: 'Logged out' });
+};
+
+module.exports = userController;

--- a/controllers/AuthController.js
+++ b/controllers/AuthController.js
@@ -25,7 +25,6 @@ userController.doRegister = function (req, res) {
         return res.send({ message: `AuthController Error: ${err}` });
       }
       return passport.authenticate('local')(req, res, () => {
-        console.log(user);
         res.send({ message: `Welcome. You are ${user.username}.` });
       });
     },
@@ -40,7 +39,6 @@ userController.doLogin = function (req, res) {
 
 userController.logout = function (req, res) {
   req.logout();
-  console.log(req.user);
   return res.send({ message: 'Logged out' });
 };
 

--- a/graphql/mutation.js
+++ b/graphql/mutation.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console, no-underscore-dangle, no-plusplus, no-param-reassign, no-shadow */
+
 const {
   GraphQLObjectType, GraphQLString, GraphQLNonNull, GraphQLList,
 } = require('graphql');
@@ -13,49 +15,17 @@ const OrganizationModel = require('../mongoose/models/organization');
 module.exports = new GraphQLObjectType({
   name: 'Mutation',
   fields: {
-    // addUser: {
-    //   type: UserType,
-    //   args: {
-    //     username: { type: new GraphQLNonNull(GraphQLString) },
-    //     password: { type: new GraphQLNonNull(GraphQLString) },
-    //     firstname: { type: GraphQLString },
-    //     lastname: { type: GraphQLString },
-    //     role: { type: GraphQLString },
-    //     organization: { type: GraphQLString },
-    //   },
-    //   resolve(parentVal, args) {
-    //     return UserModel.findOne({ username: args.username }).then((doc) => {
-    //       if (doc) {
-    //         throw 'Username Taken';
-    //       } else {
-    //         return new UserModel({
-    //           username: args.username,
-    //           password: args.password,
-    //           organization: args.organization,
-    //         })
-    //           .save()
-    //           .then((doc) => {
-    //             if (doc) {
-    //               return doc;
-    //             }
-    //             throw 'Error creating user despite unique username';
-    //           });
-    //       }
-    //     });
-    //   },
-    // },
     deleteUser: {
       type: UserType,
       args: {
         id: { type: new GraphQLNonNull(GraphQLString) },
-        password: { type: new GraphQLNonNull(GraphQLString) },
       },
       resolve(parentVal, args) {
-        return UserModel.remove({ _id: args.id, password: args.password }).then((doc) => {
+        return UserModel.remove({ _id: args.id, password: args.password }).then((err, doc) => {
           if (!doc) {
-            throw `User Not Removed ${err}`;
+            throw new Error(`User Not Removed ${err}`);
           } else {
-            throw 'User Removed';
+            throw new Error('User Removed');
           }
         });
       },
@@ -65,32 +35,32 @@ module.exports = new GraphQLObjectType({
       args: {
         id: { type: new GraphQLNonNull(GraphQLString) },
         username: { type: GraphQLString },
-        password: { type: GraphQLString },
         firstname: { type: GraphQLString },
         lastname: { type: GraphQLString },
         role: { type: GraphQLString },
       },
-      resolve(parentVal, args) {
+      resolve(parentVal, args, { session }) {
+        console.log(session); // TODO: we don't use session but here's how to access
         const argsKeys = Object.keys(args);
         return UserModel.findById(args.id).then((doc) => {
           if (doc) {
             const docKeys = Object.keys(doc._doc);
-            for (i = 0; i < argsKeys.length; i++) {
+            for (let i = 0; i < argsKeys.length; i++) {
               const index = docKeys.indexOf(argsKeys[i]);
               console.log(index);
               if (index === -1) {
                 const newDocKey = argsKeys[i];
-                var argsChangeKey = argsKeys[i];
+                const argsChangeKey = argsKeys[i];
                 doc[newDocKey] = args[argsChangeKey];
               } else {
                 const docChangeKey = docKeys[index];
-                var argsChangeKey = argsKeys[i];
+                const argsChangeKey = argsKeys[i];
                 doc[docChangeKey] = args[argsChangeKey];
               }
             }
             return doc.save().then(doc => doc);
           }
-          throw 'No Such User';
+          throw new Error('No Such User');
         });
       },
     },
@@ -113,22 +83,22 @@ module.exports = new GraphQLObjectType({
           const docKeys = Object.keys(doc._doc);
           console.log(argsKeys);
           console.log(docKeys);
-          for (i = 0; i < argsKeys.length; i++) {
+          for (let i = 0; i < argsKeys.length; i++) {
             const index = docKeys.indexOf(argsKeys[i]);
             console.log(index);
             if (index === -1) {
               const newDocKey = argsKeys[i];
-              var argsChangeKey = argsKeys[i];
+              const argsChangeKey = argsKeys[i];
               doc[newDocKey] = args[argsChangeKey];
             } else {
               const docChangeKey = docKeys[index];
-              var argsChangeKey = argsKeys[i];
+              const argsChangeKey = argsKeys[i];
               doc[docChangeKey] = args[argsChangeKey];
             }
           }
           return doc.save().then(doc => doc);
         }
-        throw 'No Such User';
+        throw new Error('No Such User');
       });
     },
   },
@@ -144,17 +114,17 @@ module.exports = new GraphQLObjectType({
           return new OrganizationModel({
             name: args.name,
             admin: args.admin,
-            dateCreated: parseInt(Date.now()),
+            dateCreated: parseInt(Date.now(), 10),
           })
             .save()
             .then((doc) => {
               if (doc) {
                 return doc;
               }
-              throw 'Error While Trying To Save Organization';
+              throw new Error('Error While Trying To Save Organization');
             });
         }
-        throw 'No Such User';
+        throw new Error('No Such User');
       });
     },
   },
@@ -166,9 +136,9 @@ module.exports = new GraphQLObjectType({
     resolve(parentVal, args) {
       return OrganizationModel.remove({ _id: args.id }).then((doc) => {
         if (doc) {
-          throw 'Organization Removed';
+          throw new Error('Organization Removed');
         } else {
-          throw 'Error Removing Organization';
+          throw new Error('Error Removing Organization');
         }
       });
     },
@@ -188,22 +158,22 @@ module.exports = new GraphQLObjectType({
       return OrganizationModel.findById(args.id).then((doc) => {
         if (doc) {
           const docKeys = Object.keys(doc._doc);
-          for (i = 0; i < argsKeys.length; i++) {
+          for (let i = 0; i < argsKeys.length; i++) {
             const index = docKeys.indexOf(argsKeys[i]);
             console.log(index);
             if (index === -1) {
               const newDocKey = argsKeys[i];
-              var argsChangeKey = argsKeys[i];
+              const argsChangeKey = argsKeys[i];
               doc[newDocKey] = args[argsChangeKey];
             } else {
               const docChangeKey = docKeys[index];
-              var argsChangeKey = argsKeys[i];
+              const argsChangeKey = argsKeys[i];
               doc[docChangeKey] = args[argsChangeKey];
             }
           }
           return doc.save().then(doc => doc);
         }
-        throw 'No Such User';
+        throw new Error('No Such User');
       });
     },
   },

--- a/graphql/mutation.js
+++ b/graphql/mutation.js
@@ -21,9 +21,9 @@ module.exports = new GraphQLObjectType({
         id: { type: new GraphQLNonNull(GraphQLString) },
       },
       resolve(parentVal, args) {
-        return UserModel.remove({ _id: args.id, password: args.password }).then((err, doc) => {
+        return UserModel.remove({ _id: args.id, password: args.password }).then((doc) => {
           if (!doc) {
-            throw new Error(`User Not Removed ${err}`);
+            throw new Error('User Not Removed.');
           } else {
             throw new Error('User Removed');
           }
@@ -35,29 +35,14 @@ module.exports = new GraphQLObjectType({
       args: {
         id: { type: new GraphQLNonNull(GraphQLString) },
         username: { type: GraphQLString },
-        firstname: { type: GraphQLString },
-        lastname: { type: GraphQLString },
+        firstName: { type: GraphQLString },
+        lastName: { type: GraphQLString },
         role: { type: GraphQLString },
       },
-      resolve(parentVal, args, { session }) {
-        console.log(session); // TODO: we don't use session but here's how to access
-        const argsKeys = Object.keys(args);
+      resolve(parentVal, args) {
         return UserModel.findById(args.id).then((doc) => {
           if (doc) {
-            const docKeys = Object.keys(doc._doc);
-            for (let i = 0; i < argsKeys.length; i++) {
-              const index = docKeys.indexOf(argsKeys[i]);
-              console.log(index);
-              if (index === -1) {
-                const newDocKey = argsKeys[i];
-                const argsChangeKey = argsKeys[i];
-                doc[newDocKey] = args[argsChangeKey];
-              } else {
-                const docChangeKey = docKeys[index];
-                const argsChangeKey = argsKeys[i];
-                doc[docChangeKey] = args[argsChangeKey];
-              }
-            }
+            doc = Object.assign(doc, args);
             return doc.save().then(doc => doc);
           }
           throw new Error('No Such User');

--- a/graphql/mutation.js
+++ b/graphql/mutation.js
@@ -1,255 +1,210 @@
-const{
-    GraphQLObjectType,
-    GraphQLString,
-    GraphQLNonNull,
-    GraphQLList
-} = require("graphql");
+const {
+  GraphQLObjectType, GraphQLString, GraphQLNonNull, GraphQLList,
+} = require('graphql');
 
-const UserType = require("./query/user-type");
-const ClassType = require("./query/class-type");
-const AssignmentsType = require("./query/assignments-type").InputType;
-const OrganizationType = require("./query/organization-type");
-const UserModel = require("../mongoose/models/user");
-const ClassModel = require("../mongoose/models/class");
-const OrganizationModel = require("../mongoose/models/organization");
+const UserType = require('./query/user-type');
+const ClassType = require('./query/class-type');
+const AssignmentsType = require('./query/assignments-type').InputType;
+const OrganizationType = require('./query/organization-type');
+const UserModel = require('../mongoose/models/user');
+const ClassModel = require('../mongoose/models/class');
+const OrganizationModel = require('../mongoose/models/organization');
 
 module.exports = new GraphQLObjectType({
-    name:"Mutation",
-    fields:{
-        addUser:{
-            type:UserType,
-            args:{
-                username:{type: new GraphQLNonNull(GraphQLString)},
-                password:{type: new GraphQLNonNull(GraphQLString)},
-                firstname:{type: GraphQLString},
-                lastname: {type: GraphQLString},
-                role:{type: GraphQLString},
-                organization:{type: GraphQLString},
-            },
-            resolve(parentVal,args){
-                return UserModel.findOne({username:args.username}).then((doc)=>{
-                    if(doc){
-                        throw "Username Taken";
-                    }else{
-                        return new UserModel({
-                            username:args.username,
-                            password:args.password,
-                            organization:args.organization
-                        }).save().then((doc)=>{
-                            if(doc){
-                                return doc;
-                            }else{
-                                throw "Error creating user despite unique username"
-                            }
-                        })
-                    }
-                })
-            },
-        },
-            deleteUser:{
-                type:UserType,
-                args:{
-                    id:{type: new GraphQLNonNull(GraphQLString)},
-                    password:{type: new GraphQLNonNull(GraphQLString)}
-                },
-                resolve(parentVal,args){
-                    return UserModel.remove({_id:args.id,password:args.password}).then((doc)=>{
-                        if(!doc){
-                            throw "User Not Removed " + err;
-                        }else{
-                            throw "User Removed"
-                        }
-                    })
-                }
-            },
-          editUser:{
-              type:UserType,
-              args:{
-                  id:{type: new GraphQLNonNull(GraphQLString)},
-                  username:{type: GraphQLString},
-                  password:{type: GraphQLString},
-                  firstname:{type: GraphQLString},
-                  lastname:{type: GraphQLString},
-                  role:{type: GraphQLString}
-              },
-              resolve(parentVal,args){
-                  let argsKeys = Object.keys(args);
-                  return UserModel.findById(args.id).then((doc)=>{
-                     if(doc){
-                         let docKeys = Object.keys(doc._doc);
-                         for(i = 0; i<argsKeys.length;i++){
-                             var index = docKeys.indexOf(argsKeys[i]);
-                             console.log(index);
-                             if(index === -1){
-                                 var newDocKey = argsKeys[i];
-                                 var argsChangeKey = argsKeys[i];
-                                 doc[newDocKey] = args[argsChangeKey];
-                             }else{
-                                 var docChangeKey = docKeys[index];
-                                 var argsChangeKey = argsKeys[i];
-                                 doc[docChangeKey] = args[argsChangeKey];
-                             }
-                         }
-                         return doc.save().then((doc)=>{
-                             return doc;
-                         })
-                     }else{
-                         throw "No Such User"
-                     }
-                  })
-              }
-          },
-        addClass:{
-            type: ClassType,
-            args:{
-                name: {type: GraphQLNonNull(GraphQLString)},
-                section: {type: GraphQLString},
-                admin: {type: GraphQLNonNull(GraphQLString)},
-                teacher: {type: GraphQLString}
-            },
-            resolve(parentVal,args){
-                return new ClassModel({
-                    name: args.name,
-                    section: args.section,
-                    admin: args.admin,
-                    teacher: args.teacher
-                }).save().then((doc)=>{
-                    return doc;
-                })
-            }
-        },
-        removeClass:{
-            type: ClassType,
-            args:{
-                id:{type: GraphQLString}
-            },
-            resolve(parentVal,args){
-                return ClassModel.remove({_id:args.id}).then((doc)=>{
-                    if(doc){
-                        throw "User Deleted";
-                    }else{
-                        throw "No Such User";
-                    }
-                })
-            }
-        },
-        editClass:{
-        type: ClassType,
-            args:{
-                id:{type: GraphQLNonNull(GraphQLString)},
-                name: {type: GraphQLString},
-                section: {type: GraphQLString},
-                admin: {type: GraphQLString},
-                teacher: {type: GraphQLString},
-                assignments: {type:GraphQLList(AssignmentsType)},
-                students: {type:GraphQLList(UserType.InputType)}
-            },
-            resolve(parentVal,args){
-                let argsKeys = Object.keys(args);
-                return ClassModel.findById(args.id).then((doc)=>{
-                     if(doc){
-                         let docKeys = Object.keys(doc._doc);
-                         console.log(argsKeys);
-                         console.log(docKeys);
-                         for(i = 0; i<argsKeys.length;i++){
-                             var index = docKeys.indexOf(argsKeys[i]);
-                             console.log(index);
-                             if(index === -1){
-                                 var newDocKey = argsKeys[i];
-                                 var argsChangeKey = argsKeys[i];
-                                 doc[newDocKey] = args[argsChangeKey];
-                             }else{
-                                 var docChangeKey = docKeys[index];
-                                 var argsChangeKey = argsKeys[i];
-                                 doc[docChangeKey] = args[argsChangeKey];
-                             }
-                         }
-                         return doc.save().then((doc)=>{
-                             return doc;
-                         })
-                     }else{
-                         throw "No Such User"
-                     }
-                  })
-            }
+  name: 'Mutation',
+  fields: {
+    // addUser: {
+    //   type: UserType,
+    //   args: {
+    //     username: { type: new GraphQLNonNull(GraphQLString) },
+    //     password: { type: new GraphQLNonNull(GraphQLString) },
+    //     firstname: { type: GraphQLString },
+    //     lastname: { type: GraphQLString },
+    //     role: { type: GraphQLString },
+    //     organization: { type: GraphQLString },
+    //   },
+    //   resolve(parentVal, args) {
+    //     return UserModel.findOne({ username: args.username }).then((doc) => {
+    //       if (doc) {
+    //         throw 'Username Taken';
+    //       } else {
+    //         return new UserModel({
+    //           username: args.username,
+    //           password: args.password,
+    //           organization: args.organization,
+    //         })
+    //           .save()
+    //           .then((doc) => {
+    //             if (doc) {
+    //               return doc;
+    //             }
+    //             throw 'Error creating user despite unique username';
+    //           });
+    //       }
+    //     });
+    //   },
+    // },
+    deleteUser: {
+      type: UserType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLString) },
+        password: { type: new GraphQLNonNull(GraphQLString) },
+      },
+      resolve(parentVal, args) {
+        return UserModel.remove({ _id: args.id, password: args.password }).then((doc) => {
+          if (!doc) {
+            throw `User Not Removed ${err}`;
+          } else {
+            throw 'User Removed';
+          }
+        });
+      },
     },
-        addOrganization:{
-            type:OrganizationType,
-            args:{
-                name: {type: GraphQLNonNull(GraphQLString)},
-                admin: {type: GraphQLNonNull(GraphQLString)}
-            },
-            resolve(parentVal,args){
-                return UserModel.findById(args.admin).then((doc)=>{
-                    if(doc){
-                        return new OrganizationModel({
-                            name: args.name,
-                            admin: args.admin,
-                            dateCreated: parseInt(Date.now())
-                        }).save().then((doc)=>{
-                            if(doc){
-                                return doc;
-                            }else{
-                                throw "Error While Trying To Save Organization"
-                            }
-                        }) 
-                    }else{
-                        throw "No Such User";
-                    }
-                })
+    editUser: {
+      type: UserType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLString) },
+        username: { type: GraphQLString },
+        password: { type: GraphQLString },
+        firstname: { type: GraphQLString },
+        lastname: { type: GraphQLString },
+        role: { type: GraphQLString },
+      },
+      resolve(parentVal, args) {
+        const argsKeys = Object.keys(args);
+        return UserModel.findById(args.id).then((doc) => {
+          if (doc) {
+            const docKeys = Object.keys(doc._doc);
+            for (i = 0; i < argsKeys.length; i++) {
+              const index = docKeys.indexOf(argsKeys[i]);
+              console.log(index);
+              if (index === -1) {
+                const newDocKey = argsKeys[i];
+                var argsChangeKey = argsKeys[i];
+                doc[newDocKey] = args[argsChangeKey];
+              } else {
+                const docChangeKey = docKeys[index];
+                var argsChangeKey = argsKeys[i];
+                doc[docChangeKey] = args[argsChangeKey];
+              }
             }
-        },
-       removeOrganization:{
-           type:OrganizationType,
-           args:{
-               id: {type: new GraphQLNonNull(GraphQLString)},
-           },
-           resolve(parentVal, args){
-               return OrganizationModel.remove({_id: args.id}).then((doc)=>{
-                   if(doc){
-                       throw "Organization Removed";
-                   }else{
-                       throw "Error Removing Organization";
-                   }
-               })
-           }
-       },
-      editOrganization:{
-          type:OrganizationType,
-          args:{
-               id:{type: new GraphQLNonNull(GraphQLString)},
-               name:{type:GraphQLString},
-               classes: {type:GraphQLList(ClassType.InputType)},
-               teachers: {type:GraphQLList(UserType.InputType)},
-               students: {type:GraphQLList(UserType.InputType)},
-               admin: {type: GraphQLString}
-          },
-          resolve(parentVal,args){
-            let argsKeys = Object.keys(args);
-            return OrganizationModel.findById(args.id).then((doc)=>{
-                     if(doc){
-                         let docKeys = Object.keys(doc._doc);
-                         for(i = 0; i<argsKeys.length;i++){
-                             var index = docKeys.indexOf(argsKeys[i]);
-                             console.log(index);
-                             if(index === -1){
-                                 var newDocKey = argsKeys[i];
-                                 var argsChangeKey = argsKeys[i];
-                                 doc[newDocKey] = args[argsChangeKey];
-                             }else{
-                                 var docChangeKey = docKeys[index];
-                                 var argsChangeKey = argsKeys[i];
-                                 doc[docChangeKey] = args[argsChangeKey];
-                             }
-                         }
-                         return doc.save().then((doc)=>{
-                             return doc;
-                         })
-                     }else{
-                         throw "No Such User"
-                     }
-          })
+            return doc.save().then(doc => doc);
+          }
+          throw 'No Such User';
+        });
+      },
+    },
+  },
+  editClass: {
+    type: ClassType,
+    args: {
+      id: { type: GraphQLNonNull(GraphQLString) },
+      name: { type: GraphQLString },
+      section: { type: GraphQLString },
+      admin: { type: GraphQLString },
+      teacher: { type: GraphQLString },
+      assignments: { type: GraphQLList(AssignmentsType) },
+      students: { type: GraphQLList(UserType.InputType) },
+    },
+    resolve(parentVal, args) {
+      const argsKeys = Object.keys(args);
+      return ClassModel.findById(args.id).then((doc) => {
+        if (doc) {
+          const docKeys = Object.keys(doc._doc);
+          console.log(argsKeys);
+          console.log(docKeys);
+          for (i = 0; i < argsKeys.length; i++) {
+            const index = docKeys.indexOf(argsKeys[i]);
+            console.log(index);
+            if (index === -1) {
+              const newDocKey = argsKeys[i];
+              var argsChangeKey = argsKeys[i];
+              doc[newDocKey] = args[argsChangeKey];
+            } else {
+              const docChangeKey = docKeys[index];
+              var argsChangeKey = argsKeys[i];
+              doc[docChangeKey] = args[argsChangeKey];
+            }
+          }
+          return doc.save().then(doc => doc);
         }
-    }
-    }
-})
+        throw 'No Such User';
+      });
+    },
+  },
+  addOrganization: {
+    type: OrganizationType,
+    args: {
+      name: { type: GraphQLNonNull(GraphQLString) },
+      admin: { type: GraphQLNonNull(GraphQLString) },
+    },
+    resolve(parentVal, args) {
+      return UserModel.findById(args.admin).then((doc) => {
+        if (doc) {
+          return new OrganizationModel({
+            name: args.name,
+            admin: args.admin,
+            dateCreated: parseInt(Date.now()),
+          })
+            .save()
+            .then((doc) => {
+              if (doc) {
+                return doc;
+              }
+              throw 'Error While Trying To Save Organization';
+            });
+        }
+        throw 'No Such User';
+      });
+    },
+  },
+  removeOrganization: {
+    type: OrganizationType,
+    args: {
+      id: { type: new GraphQLNonNull(GraphQLString) },
+    },
+    resolve(parentVal, args) {
+      return OrganizationModel.remove({ _id: args.id }).then((doc) => {
+        if (doc) {
+          throw 'Organization Removed';
+        } else {
+          throw 'Error Removing Organization';
+        }
+      });
+    },
+  },
+  editOrganization: {
+    type: OrganizationType,
+    args: {
+      id: { type: new GraphQLNonNull(GraphQLString) },
+      name: { type: GraphQLString },
+      classes: { type: GraphQLList(ClassType.InputType) },
+      teachers: { type: GraphQLList(UserType.InputType) },
+      students: { type: GraphQLList(UserType.InputType) },
+      admin: { type: GraphQLString },
+    },
+    resolve(parentVal, args) {
+      const argsKeys = Object.keys(args);
+      return OrganizationModel.findById(args.id).then((doc) => {
+        if (doc) {
+          const docKeys = Object.keys(doc._doc);
+          for (i = 0; i < argsKeys.length; i++) {
+            const index = docKeys.indexOf(argsKeys[i]);
+            console.log(index);
+            if (index === -1) {
+              const newDocKey = argsKeys[i];
+              var argsChangeKey = argsKeys[i];
+              doc[newDocKey] = args[argsChangeKey];
+            } else {
+              const docChangeKey = docKeys[index];
+              var argsChangeKey = argsKeys[i];
+              doc[docChangeKey] = args[argsChangeKey];
+            }
+          }
+          return doc.save().then(doc => doc);
+        }
+        throw 'No Such User';
+      });
+    },
+  },
+});

--- a/graphql/query/root.js
+++ b/graphql/query/root.js
@@ -1,63 +1,56 @@
-const{
-    GraphQLObjectType,
-    GraphQLString,
-    GraphQLNonNull
-} = require("graphql");
+const { GraphQLObjectType, GraphQLString, GraphQLNonNull } = require('graphql');
 
-const UserType = require("./user-type");
-const ClassType = require("./class-type");
-const OrganizationType = require("./organization-type");
-const UserModel = require("../../mongoose/models/user");
-const ClassModel = require("../../mongoose/models/class");
-const OrganizationModel = require("../../mongoose/models/class");
+const UserType = require('./user-type');
+const ClassType = require('./class-type');
+const OrganizationType = require('./organization-type');
+const UserModel = require('../../mongoose/models/user');
+const ClassModel = require('../../mongoose/models/class');
+const OrganizationModel = require('../../mongoose/models/class');
 
 module.exports = new GraphQLObjectType({
-    name:"RootQuery",
-    fields:{
-        user:{
-            type: UserType,
-            args:{
-                id:{type: new GraphQLNonNull(GraphQLString)}
-            },
-            resolve(parentVal,args){
-            return UserModel.findById(args.id).then((doc)=>{
-                if(doc){
-                    return doc;
-                }else{
-                    throw "No such user";
-                }
-            })
-        }
-        },
-     class:{
-         type: ClassType,
-         args:{
-             id:{type: new GraphQLNonNull(GraphQLString)}
-         },
-        resolve(parentVal,args){
-            return ClassModel.findById(args.id).then((doc)=>{
-                if(doc){
-                    return doc;
-                }else{
-                    throw "No such user";
-                }
-            })
-        }
+  name: 'RootQuery',
+  fields: {
+    user: {
+      type: UserType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLString) },
+      },
+      resolve(parentVal, args) {
+        return UserModel.findById(args.id).then((doc) => {
+          if (doc) {
+            return doc;
+          }
+          throw 'No such user';
+        });
+      },
     },
-   organization:{
-       type: OrganizationType,
-       args:{
-           id:{type: new GraphQLNonNull(GraphQLString)}
-       },
-       resolve(parentVal,args){
-           return OrganizationModel.findById(args.id).then((doc)=>{
-               if(doc){
-                   return doc;
-               }else{
-                   return "No Such User";
-               }
-           })
-       }
-   }
-    }
-}) 
+    class: {
+      type: ClassType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLString) },
+      },
+      resolve(parentVal, args) {
+        return ClassModel.findById(args.id).then((doc) => {
+          if (doc) {
+            return doc;
+          }
+          throw 'No such user';
+        });
+      },
+    },
+    organization: {
+      type: OrganizationType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLString) },
+      },
+      resolve(parentVal, args) {
+        return OrganizationModel.findById(args.id).then((doc) => {
+          if (doc) {
+            return doc;
+          }
+          return 'No Such User';
+        });
+      },
+    },
+  },
+});

--- a/graphql/query/root.js
+++ b/graphql/query/root.js
@@ -20,7 +20,7 @@ module.exports = new GraphQLObjectType({
           if (doc) {
             return doc;
           }
-          throw 'No such user';
+          throw new Error('No such user');
         });
       },
     },
@@ -34,7 +34,7 @@ module.exports = new GraphQLObjectType({
           if (doc) {
             return doc;
           }
-          throw 'No such user';
+          throw new Error('No such user');
         });
       },
     },

--- a/graphql/query/schema.js
+++ b/graphql/query/schema.js
@@ -1,10 +1,8 @@
-const{
-    GraphQLSchema
-} = require("graphql")
-const root = require("./root");
-const mutation = require("../mutation");
+const { GraphQLSchema } = require('graphql');
+const root = require('./root');
+const mutation = require('../mutation');
 
 module.exports = new GraphQLSchema({
-   query:root,
-   mutation:mutation
+  query: root,
+  mutation,
 });

--- a/graphql/query/user-type.js
+++ b/graphql/query/user-type.js
@@ -1,29 +1,25 @@
-const{
-    GraphQLObjectType,
-    GraphQLString,
-    GraphQLInputObjectType
-} = require("graphql");
+const { GraphQLObjectType, GraphQLString, GraphQLInputObjectType } = require('graphql');
 
 module.exports = new GraphQLObjectType({
-    name:"User",
-    fields:{
-        id:{type: GraphQLString},
-        username:{type: GraphQLString},
-        firstName:{type: GraphQLString},
-        lastName: {type: GraphQLString},
-        organization:{type: GraphQLString},
-        role:{type: GraphQLString}
-    }
-})
+  name: 'User',
+  fields: {
+    id: { type: GraphQLString },
+    username: { type: GraphQLString },
+    firstName: { type: GraphQLString },
+    lastName: { type: GraphQLString },
+    organization: { type: GraphQLString },
+    role: { type: GraphQLString },
+  },
+});
 
 module.exports.InputType = new GraphQLInputObjectType({
-    name:"UserInputType",
-    fields:{
-        id:{type: GraphQLString},
-        username:{type: GraphQLString},
-        firstName:{type: GraphQLString},
-        lastName: {type: GraphQLString},
-        organization:{type: GraphQLString},
-        role:{type: GraphQLString}
-    }
-})
+  name: 'UserInputType',
+  fields: {
+    id: { type: GraphQLString },
+    username: { type: GraphQLString },
+    firstName: { type: GraphQLString },
+    lastName: { type: GraphQLString },
+    organization: { type: GraphQLString },
+    role: { type: GraphQLString },
+  },
+});

--- a/mongoose/models/class.js
+++ b/mongoose/models/class.js
@@ -1,28 +1,33 @@
-const mongoose = require("mongoose");
-const Schema = mongoose.Schema;
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
 
 const schoolClass = new Schema({
-    name: String,
-    section: String,
-    admin: String,
-    teacher: String,
-    students: [{
-        id: String,
-        name: String,
-        grades: [{
-            assignment: String,
-            grade: Number
-        }]
-    }],
-    assignments:[
+  name: String,
+  section: String,
+  admin: String,
+  teacher: String,
+  students: [
+    {
+      id: String,
+      name: String,
+      grades: [
         {
-            startDate: String,
-            endDate: String,
-            title: String,
-            details: String,
-            type: String
-        }
-    ]
-})
+          assignment: String,
+          grade: Number,
+        },
+      ],
+    },
+  ],
+  assignments: [
+    {
+      startDate: String,
+      endDate: String,
+      title: String,
+      details: String,
+      type: String,
+    },
+  ],
+});
 
-module.exports = mongoose.model("classe", schoolClass);
+module.exports = mongoose.model('classe', schoolClass);

--- a/mongoose/models/organization.js
+++ b/mongoose/models/organization.js
@@ -1,13 +1,14 @@
-const mongoose = require("mongoose");
-const Schema = mongoose.Schema;
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
 
 const organization = new Schema({
-   name: String,
-   classes: Array,
-   teachers: Array,
-   students: Array,
-   dateCreated: String,
-   admin: String
+  name: String,
+  classes: Array,
+  teachers: Array,
+  students: Array,
+  dateCreated: String,
+  admin: String,
 });
 
-module.exports = mongoose.model("organization", organization);
+module.exports = mongoose.model('organization', organization);

--- a/mongoose/models/user.js
+++ b/mongoose/models/user.js
@@ -1,14 +1,18 @@
-const mongoose = require("mongoose");
-const Schema = mongoose.Schema;
+const mongoose = require('mongoose');
+const passportLocalMongoose = require('passport-local-mongoose');
+
+const { Schema } = mongoose;
 
 const user = new Schema({
-    username: String,
-    password: String,
-    firstName: String,
-    lastName: String,
-    role: String,
-    organization: String,
-    classes: Array
-})
+  username: String,
+  password: String,
+  firstName: String,
+  lastName: String,
+  role: String,
+  organization: String,
+  classes: Array,
+});
 
-module.exports = mongoose.model("user",user);
+user.plugin(passportLocalMongoose);
+
+module.exports = mongoose.model('user', user);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "blueboard-dev-data",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -18,6 +18,47 @@
         "negotiator": "0.6.1"
       }
     },
+    "acorn": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+      "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
+    "ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
+    },
     "ansi-align": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
@@ -25,6 +66,12 @@
       "requires": {
         "string-width": "2.1.1"
       }
+    },
+    "ansi-escapes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "dev": true
     },
     "ansi-regex": {
       "version": "3.0.0",
@@ -48,6 +95,24 @@
         "normalize-path": "2.1.1"
       }
     },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "aria-query": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-0.7.0.tgz",
+      "integrity": "sha512-/r2lHl09V3o74+2MLKEdewoj37YZqiQZnfen1O4iNlrOjUgeKuu1U2yF3iKh6HJxqF+OXkLMfQv65Z/cvxD6vA==",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7"
+      }
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -68,15 +133,58 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0"
+      }
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+    },
+    "ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+      "dev": true
     },
     "async": {
       "version": "2.1.4",
@@ -95,6 +203,68 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
       "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10="
+    },
+    "axobject-query": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-0.1.0.tgz",
+      "integrity": "sha1-YvWdvFnJ+SQnWco0mWDnov48NsA=",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7"
+      }
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -188,6 +358,12 @@
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
       "integrity": "sha1-k8ENOeqltYQVy8QFLz5T5WKwtyw="
     },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -209,6 +385,21 @@
         "unset-value": "1.0.0"
       }
     },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
     "camelcase": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -229,6 +420,12 @@
         "supports-color": "4.5.0"
       }
     },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
     "chokidar": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.0.tgz",
@@ -246,6 +443,12 @@
         "path-is-absolute": "1.0.1",
         "readdirp": "2.1.0"
       }
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -324,6 +527,27 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
     },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -356,6 +580,17 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      }
+    },
     "configstore": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
@@ -368,6 +603,12 @@
         "write-file-atomic": "2.3.0",
         "xdg-basedir": "3.0.0"
       }
+    },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
     },
     "content-disposition": {
       "version": "0.5.2",
@@ -394,10 +635,21 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "crc": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
+      "integrity": "sha1-naHpgOO9RPxck79as9ozeNheRms="
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -422,6 +674,12 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
+    "damerau-levenshtein": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
+      "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
+      "dev": true
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -440,12 +698,51 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
       "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
     "define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
       "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
       "requires": {
         "is-descriptor": "1.0.2"
+      }
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "depd": {
@@ -457,6 +754,15 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2"
+      }
     },
     "dot-prop": {
       "version": "4.2.0",
@@ -481,10 +787,58 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "emoji-regex": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
+      "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
+      "dev": true
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
+      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -495,6 +849,226 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "eslint": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.16.0.tgz",
+      "integrity": "sha512-YVXV4bDhNoHHcv0qzU4Meof7/P26B4EuaktMi5L1Tnt52Aov85KmYA8c5D+xyZr/BkhvwUqr011jDSD/QTULxg==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.3.0",
+        "concat-stream": "1.6.0",
+        "cross-spawn": "5.1.0",
+        "debug": "3.1.0",
+        "doctrine": "2.1.0",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "3.5.2",
+        "esquery": "1.0.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "11.3.0",
+        "ignore": "3.3.7",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.3.0",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.10.0",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.5.0",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "4.0.2",
+        "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-config-airbnb": {
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-16.1.0.tgz",
+      "integrity": "sha512-zLyOhVWhzB/jwbz7IPSbkUuj7X2ox4PHXTcZkEmDqTvd0baJmJyuxlFPDlZOE/Y5bC+HQRaEkT3FoHo9wIdRiw==",
+      "dev": true,
+      "requires": {
+        "eslint-config-airbnb-base": "12.1.0"
+      }
+    },
+    "eslint-config-airbnb-base": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz",
+      "integrity": "sha512-/vjm0Px5ZCpmJqnjIzcFb9TKZrKWz0gnuG/7Gfkt0Db1ELJR51xkZth+t14rYdqWgX836XbuxtArbIHlVhbLBA==",
+      "dev": true,
+      "requires": {
+        "eslint-restricted-globals": "0.1.1"
+      }
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "resolve": "1.5.0"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
+      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "pkg-dir": "1.0.0"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
+      "integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "0.3.2",
+        "eslint-module-utils": "2.1.1",
+        "has": "1.0.1",
+        "lodash.cond": "4.5.2",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "2.0.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-jsx-a11y": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.3.tgz",
+      "integrity": "sha1-VFg9GuRCSDFi4EDhPMMYZUZRAOU=",
+      "dev": true,
+      "requires": {
+        "aria-query": "0.7.0",
+        "array-includes": "3.0.3",
+        "ast-types-flow": "0.0.7",
+        "axobject-query": "0.1.0",
+        "damerau-levenshtein": "1.0.4",
+        "emoji-regex": "6.5.1",
+        "jsx-ast-utils": "2.0.1"
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.6.1.tgz",
+      "integrity": "sha512-30aMOHWX/DOaaLJVBHz6RMvYM2qy5GH63+y2PLFdIrYe4YLtODFmT3N1YA7ZqUnaBweVbedr4K4cqxOlWAPjIw==",
+      "dev": true,
+      "requires": {
+        "doctrine": "2.1.0",
+        "has": "1.0.1",
+        "jsx-ast-utils": "2.0.1",
+        "prop-types": "15.6.0"
+      }
+    },
+    "eslint-restricted-globals": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
+      "integrity": "sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc=",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.3.0",
+        "acorn-jsx": "3.0.1"
+      }
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
@@ -652,12 +1226,39 @@
         "raw-body": "2.3.2"
       }
     },
+    "express-session": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.15.6.tgz",
+      "integrity": "sha512-r0nrHTCYtAMrFwZ0kBzZEXa1vtPVrw0dKvGSrKP4dahwBQ1BJpF2/y1Pp4sCD/0kvxV4zZeclyvfmw0B4RMJQA==",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "crc": "3.4.4",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "on-headers": "1.0.1",
+        "parseurl": "1.3.2",
+        "uid-safe": "2.1.5",
+        "utils-merge": "1.0.1"
+      }
+    },
     "extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "requires": {
         "is-extendable": "0.1.1"
+      }
+    },
+    "external-editor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "dev": true,
+      "requires": {
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.19",
+        "tmp": "0.0.33"
       }
     },
     "extglob": {
@@ -673,6 +1274,58 @@
         "regex-not": "1.0.0",
         "snapdragon": "0.8.1",
         "to-regex": "3.0.1"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fbjs": {
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "dev": true,
+      "requires": {
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.17"
+      }
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
       }
     },
     "fill-range": {
@@ -700,10 +1353,38 @@
         "unpipe": "1.0.0"
       }
     },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "forwarded": {
       "version": "0.1.2",
@@ -727,6 +1408,12 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "1.1.3",
@@ -1517,6 +2204,23 @@
         }
       }
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "generaterr": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/generaterr/-/generaterr-1.5.0.tgz",
+      "integrity": "sha1-sM62zFFk3yoGEzjMNAqGFTlcUvw="
+    },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -1526,6 +2230,20 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "glob-parent": {
       "version": "3.1.0",
@@ -1552,6 +2270,34 @@
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "requires": {
         "ini": "1.3.5"
+      }
+    },
+    "globals": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+      "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "got": {
@@ -1583,6 +2329,32 @@
       "integrity": "sha512-Hn9rdu4zacplKXNrLCvR8YFiTGnbM4Zw/UH8FDmzBDsH7ou40lSNH4tIlsxcYnz2TGNVJCpu1WxCM23yd6kzhA==",
       "requires": {
         "iterall": "1.1.3"
+      }
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
       }
     },
     "has-flag": {
@@ -1619,6 +2391,12 @@
         }
       }
     },
+    "hosted-git-info": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "dev": true
+    },
     "http-errors": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
@@ -1647,6 +2425,12 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
+    "ignore": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "dev": true
+    },
     "ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
@@ -1662,6 +2446,16 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -1671,6 +2465,28 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.3.0",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.1.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.4",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
+      }
     },
     "ipaddr.js": {
       "version": "1.5.2",
@@ -1685,6 +2501,12 @@
         "kind-of": "6.0.2"
       }
     },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -1698,6 +2520,21 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
     "is-data-descriptor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
@@ -1705,6 +2542,12 @@
       "requires": {
         "kind-of": "6.0.2"
       }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "1.0.2",
@@ -1784,6 +2627,21 @@
         "is-number": "3.0.0"
       }
     },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.1"
+      }
+    },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
@@ -1800,10 +2658,31 @@
         "isobject": "3.0.1"
       }
     },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
     },
     "is-retry-allowed": {
       "version": "1.1.0",
@@ -1814,6 +2693,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -1830,10 +2715,57 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.3"
+      }
+    },
     "iterall": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.1.3.tgz",
       "integrity": "sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ=="
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "jsx-ast-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
+      "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+      "dev": true,
+      "requires": {
+        "array-includes": "3.0.3"
+      }
     },
     "kareem": {
       "version": "2.0.2",
@@ -1861,15 +2793,78 @@
         "set-getter": "0.1.0"
       }
     },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
+    "lodash.cond": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
+      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
+      "dev": true
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
     },
     "lowercase-keys": {
       "version": "1.0.0",
@@ -1964,6 +2959,12 @@
         "mime-db": "1.30.0"
       }
     },
+    "mimic-fn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -1993,6 +2994,23 @@
           "requires": {
             "is-plain-object": "2.0.4"
           }
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         }
       }
     },
@@ -2064,6 +3082,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
     "nan": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
@@ -2095,10 +3119,26 @@
         }
       }
     },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
     },
     "nodemon": {
       "version": "1.14.11",
@@ -2134,6 +3174,18 @@
         "abbrev": "1.1.1"
       }
     },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.1"
+      }
+    },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -2149,6 +3201,12 @@
       "requires": {
         "path-key": "2.0.1"
       }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -2211,6 +3269,12 @@
         }
       }
     },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
+    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -2235,10 +3299,77 @@
         "ee-first": "1.1.1"
       }
     },
+    "on-headers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-limit": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "1.2.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
     },
     "package-json": {
       "version": "4.0.1",
@@ -2251,6 +3382,15 @@
         "semver": "5.5.0"
       }
     },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
+    },
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
@@ -2261,10 +3401,63 @@
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
+    "passport": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.0.tgz",
+      "integrity": "sha1-xQlWkTR71a07XhgCOMORTRbwWBE=",
+      "requires": {
+        "passport-strategy": "1.0.0",
+        "pause": "0.0.1"
+      }
+    },
+    "passport-local": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
+      "integrity": "sha1-H+YyaMkudWBmJkN+O5BmYsFbpu4=",
+      "requires": {
+        "passport-strategy": "1.0.0"
+      }
+    },
+    "passport-local-mongoose": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/passport-local-mongoose/-/passport-local-mongoose-4.4.0.tgz",
+      "integrity": "sha512-a0O6Me/4SWI5yhePlQKgvREwGLxJyRWzgfCJW+hbXkIRlct5Xd+upl9IDgkbprDo5j6b4702L/pZ7weSHeKxfA==",
+      "requires": {
+        "debug": "3.1.0",
+        "generaterr": "1.5.0",
+        "passport-local": "1.0.0",
+        "scmp": "2.0.0",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
     "path-dirname": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -2281,10 +3474,38 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "path-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "dev": true,
+      "requires": {
+        "pify": "2.3.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "pause-stream": {
       "version": "0.0.11",
@@ -2299,10 +3520,46 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "pkg-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2"
+      }
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -2313,6 +3570,32 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "prop-types": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+      "dev": true,
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
     },
     "proxy-addr": {
       "version": "2.0.2",
@@ -2349,6 +3632,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
+    "random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
+    },
     "range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -2374,6 +3662,38 @@
         "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
+      }
+    },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
       }
     },
     "readable-stream": {
@@ -2446,6 +3766,24 @@
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+          "dev": true
+        }
+      }
+    },
     "require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
@@ -2453,6 +3791,15 @@
       "requires": {
         "resolve-from": "2.0.0",
         "semver": "5.5.0"
+      }
+    },
+    "resolve": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
       }
     },
     "resolve-from": {
@@ -2465,10 +3812,58 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "4.0.8"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "scmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/scmp/-/scmp-2.0.0.tgz",
+      "integrity": "sha1-JHEQ7yLM+JexOj8KvdtSeCOTzWo="
     },
     "semver": {
       "version": "5.5.0",
@@ -2538,6 +3933,12 @@
         "split-string": "3.1.0"
       }
     },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
+    },
     "setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
@@ -2560,6 +3961,15 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0"
+      }
     },
     "sliced": {
       "version": "1.0.1",
@@ -2692,6 +4102,27 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+      "dev": true
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "dev": true
+    },
     "split": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
@@ -2726,6 +4157,12 @@
           }
         }
       }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "static-extend": {
       "version": "0.1.2",
@@ -2835,6 +4272,12 @@
         "ansi-regex": "3.0.0"
       }
     },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -2853,6 +4296,20 @@
         "has-flag": "2.0.0"
       }
     },
+    "table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "ajv-keywords": "2.1.1",
+        "chalk": "2.3.0",
+        "lodash": "4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "2.1.1"
+      }
+    },
     "term-size": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -2860,6 +4317,12 @@
       "requires": {
         "execa": "0.7.0"
       }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
     },
     "through": {
       "version": "2.3.8",
@@ -2870,6 +4333,15 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -2977,6 +4449,15 @@
         "nopt": "1.0.10"
       }
     },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
     "type-is": {
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
@@ -2984,6 +4465,26 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "2.1.17"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "ua-parser-js": {
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
+      "dev": true
+    },
+    "uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "requires": {
+        "random-bytes": "1.0.0"
       }
     },
     "undefsafe": {
@@ -3182,10 +4683,26 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "whatwg-fetch": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
+      "dev": true
     },
     "which": {
       "version": "1.3.0",
@@ -3201,6 +4718,27 @@
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "requires": {
         "string-width": "2.1.1"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
       }
     },
     "write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
-    "server": "nodemon app,js",
+    "server": "nodemon app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -21,8 +21,19 @@
   "dependencies": {
     "express": "^4.16.2",
     "express-graphql": "^0.6.11",
+    "express-session": "^1.15.6",
     "graphql": "^0.12.3",
     "mongoose": "^5.0.2",
-    "nodemon": "^1.14.11"
+    "nodemon": "^1.14.11",
+    "passport": "^0.4.0",
+    "passport-local": "^1.0.0",
+    "passport-local-mongoose": "^4.4.0"
+  },
+  "devDependencies": {
+    "eslint": "^4.16.0",
+    "eslint-config-airbnb": "^16.1.0",
+    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-jsx-a11y": "^6.0.3",
+    "eslint-plugin-react": "^7.6.1"
   }
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,0 +1,12 @@
+const express = require('express');
+
+const router = express.Router();
+const auth = require('../controllers/AuthController.js');
+
+router.post('/register', auth.doRegister);
+router.post('/login', auth.doLogin);
+router.post('/logout', auth.logout);
+
+router.get('*', (req, res) => res.send({ message: 'Hello' }));
+
+module.exports = router;


### PR DESCRIPTION
incorporates passport-local for username and password authentication, using routes at `/register`, `/login`, and `/logout`. Passport handles creating user records per the provided Schema in lieu of a graphQL `addUser` mutation. (While this detracts from being "pure" gQL, it provides a painless way to have passwords salted and hashed, instead of being stored in plaintext on mLab or localhost.)